### PR TITLE
Deploy Pages automatically after approved main merges

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,6 +1,8 @@
 name: Deploy Portfolio to GitHub Pages
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Release policy simplification

Move GitHub Pages from manual-only workflow dispatch to automatic deployment on pushes to `main`, while retaining `workflow_dispatch` as an operational fallback.

The human production gate remains the reviewed/approved PR merge. Deployment becomes the automated consequence of changing production authority (`main`).

This removes the temporary state where `main` and the public Pages site can diverge after an approved merge. Existing build, blog-integrity, public-asset, route, and internal-link gates remain inside the deployment workflow.

P7 is already merged to `main`; merging this workflow change will automatically build and publish the current `main`, including P7.