### PR TITLE
INFRA: stop retaining successful Playwright reports

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -61,13 +61,11 @@ jobs:
       - name: Run browser smoke tests
         run: npm run test:smoke
 
-      - name: Upload Playwright evidence
-        if: always()
+      - name: Upload Playwright failure evidence
+        if: failure()
         uses: actions/upload-artifact@v5
         with:
-          name: playwright-smoke-evidence
-          path: |
-            playwright-report/
-            test-results/
-          retention-days: 7
+          name: playwright-smoke-failure-evidence
+          path: test-results/
+          retention-days: 1
           if-no-files-found: warn

--- a/docs/versioning/contactgilmore-portfolio/02_VALIDATION_AND_EVIDENCE.md
+++ b/docs/versioning/contactgilmore-portfolio/02_VALIDATION_AND_EVIDENCE.md
@@ -17,3 +17,21 @@ GitHub Pages deployment proof
 ```
 
 Claims must match evidence. A green build alone is not production acceptance.
+
+## CI evidence-storage law
+
+Routine successful browser validation is proved by the exact-head Actions run, test summary, and deployment/source identity. A successful Playwright run does not require a large retained HTML/report artifact merely for convenience.
+
+For this public portfolio:
+
+```text
+successful Playwright run = Actions log/status is normal durable evidence
+Playwright artifact upload = failure evidence only
+failure payload = smallest useful diagnostic set
+transient failure-artifact retention = 1 day by default
+self-hosted evidence storage = prohibited for ordinary public-repository PR/fork CI
+```
+
+This repository intentionally stays on GitHub-hosted runners because public pull-request/fork code must not be exposed to private self-hosted infrastructure. That security boundary means local Node3 storage is not the default evidence sink here. The correct optimization is to avoid cloud artifact creation on successful runs and retain only bounded short-lived failure diagnostics.
+
+Large repeated browser reports are not release authority. Production acceptance remains the combination of exact source identity, green claim-matching validation, owner approval where required, merge to `main`, and successful Pages deployment.


### PR DESCRIPTION
## Purpose
Stop repeated ~100 MB Playwright smoke artifacts from consuming account Actions artifact storage while preserving claim-matching CI evidence.

## Evidence
The live artifact inventory contains multiple unexpired `playwright-smoke-evidence` packages at roughly 100.6 MB each from successful Aug. 11 runs. The workflow currently uploads both `playwright-report/` and `test-results/` on every run and retains them for seven days.

## Changes
- Successful Playwright runs no longer upload an artifact; the exact-head Actions result and test summary remain the normal evidence.
- Failure diagnostics upload only `test-results/`, only on failure, with one-day retention.
- Versioning evidence authority records the bounded CI evidence-storage policy.

## Security boundary
This public repository remains on GitHub-hosted runners. It does not use Node3/self-hosted storage because untrusted public PR/fork execution must not be exposed to private infrastructure.

## Boundaries
- No site content or visual changes.
- No deployment behavior changes.
- No self-hosted runner registration.
- No sensitive/private data.
- Historical artifacts are not deleted by this PR; existing unexpired ~100 MB packages age out separately.
