### PR TITLE
PORTFOLIO: reduce Pages artifact churn

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,14 @@ name: Deploy Portfolio to GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'astro.config.mjs'
+      - 'tsconfig.json'
+      - 'src/**'
+      - 'public/**'
+      - 'scripts/**'
   workflow_dispatch:
 
 permissions:
@@ -12,7 +20,7 @@ permissions:
 
 concurrency:
   group: github-pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Purpose
Reduce GitHub Actions artifact accrual without changing the public site or sacrificing deployment capability.

## Change
- Pages deploy now runs only when site/build inputs change;
- governance/docs-only commits no longer package the ~11.6 MB Pages artifact;
- rapid successive site commits cancel superseded deployment work;
- manual deployment remains available through `workflow_dispatch`.

The Pages deployment artifact remains because the current GitHub Pages Actions publishing mode requires it.